### PR TITLE
Prevent calling requestsDismissalOfViewController

### DIFF
--- a/BraintreePayPal/BTPayPalDriver.m
+++ b/BraintreePayPal/BTPayPalDriver.m
@@ -317,7 +317,10 @@ typedef NS_ENUM(NSUInteger, BTPayPalPaymentType) {
 - (void)setAppSwitchReturnBlock:(void (^)(BTPayPalAccountNonce *tokenizedAccount, NSError *error))completionBlock
                  forPaymentType:(BTPayPalPaymentType)paymentType {
     appSwitchReturnBlock = ^(NSURL *url) {
-        [self informDelegatePresentingViewControllerNeedsDismissal];
+        if (self.safariViewController) {
+          [self informDelegatePresentingViewControllerNeedsDismissal];
+        }
+
         [self informDelegateWillProcessAppSwitchReturn];
         
         // Before parsing the return URL, check whether the user cancelled by breaking


### PR DESCRIPTION
This fix prevents calling requestsDismissalOfViewController when there is nothing to dismiss. The same way `requestsPresentationOfViewController` is not being called.

This is also crashing on runtime on swift as this is passing `nil` to a function signature that is mark as `non_null`.
